### PR TITLE
Fix dependency version add php 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^8.0",
         "picqer/bol-retailer-php-client": "^v1.3.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^8.0",
-        "picqer/bol-retailer-php-client": "^1.4"
+        "picqer/bol-retailer-php-client": "^v1.3.5"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Fix for when installing the latest version:
`- homedesignshops/laravel-bol-com-retailer v2.0 requires picqer/bol-retailer-php-client ^1.4 -> found picqer/bol-retailer-php-client[dev-retailer-api-v3-and-v4, dev-retailer-api-v4-generated, dev-retailer-api-v4, dev-main, dev-better-error-handling, v1.0.0, ..., v1.3.5] but it does not match the constraint.`

Laravel 8 requires PHP 7.3+ , updated requirements so you can also use PHP 7.3

Note, dependency 'picqer/bol-retailer-php-client' requires Guzzle ^6.3 and will give a conflict when you install this package on a Laravel 8 project. Did a pull request for Guzzle 7 support, https://github.com/picqer/bol-retailer-php-client/pull/20 


